### PR TITLE
Support disabling the Item.ID lookup cache.

### DIFF
--- a/database.go
+++ b/database.go
@@ -1,6 +1,7 @@
 package rss
 
 var database *db
+var disabled bool
 
 func init() {
 	database = NewDB()
@@ -19,7 +20,9 @@ func (d *db) Run() {
 
 	for {
 		s = <-d.req
-		if _, ok := d.known[s]; ok {
+		if disabled {
+			d.res <- false
+		} else if _, ok := d.known[s]; ok {
 			d.res <- true
 		} else {
 			d.res <- false

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,46 @@
+package rss
+
+import (
+	"testing"
+)
+
+var fixture = "Item.ID"
+
+func TestDatabaseEnabled(t *testing.T) {
+	if database.req <- fixture; <-database.res {
+		t.Error("Should have not found the fixture string.")
+	}
+	if database.req <- fixture; !<-database.res {
+		t.Error("Should have found the fixture string.")
+	}
+}
+
+func TestDatabaseDisabled(t *testing.T) {
+	CacheParsedItemIDs(false)
+
+	if database.req <- fixture; <-database.res {
+		t.Error("Should have not found the fixture string even though it was recorded.")
+	}
+
+	n := len(database.known)
+	if database.req <- "foo"; <-database.res || len(database.known) != n {
+		t.Error("Should not record a new entry.")
+	}
+}
+
+func TestDatabaseReenabled(t *testing.T) {
+	CacheParsedItemIDs(true)
+
+	if database.req <- fixture; !<-database.res {
+		t.Error("Should have found the fixture string again.")
+	}
+
+	n := len(database.known)
+	if database.req <- "foo"; <-database.res || len(database.known) != n+1 {
+		t.Error("Should record a new entry.")
+	}
+
+	if database.req <- "foo"; !<-database.res {
+		t.Error("Should find the new entry.")
+	}
+}

--- a/rss.go
+++ b/rss.go
@@ -24,6 +24,14 @@ func Parse(data []byte) (*Feed, error) {
 	panic("Unreachable.")
 }
 
+// CacheParsedItemIDs enables or disable Item.ID caching when parsing feeds.
+// Returns whether Item.ID were cached prior to function call.
+func CacheParsedItemIDs(flag bool) (didCache bool) {
+	didCache = !disabled
+	disabled = !flag
+	return
+}
+
 // Fetch downloads and parses the RSS feed at the given URL
 func Fetch(url string) (*Feed, error) {
 	resp, err := http.Get(url)


### PR DESCRIPTION
The default remains caching enabled.
