### PR TITLE
add `dc:date` item support

### DIFF
--- a/rss 1.0.go
+++ b/rss 1.0.go
@@ -87,6 +87,11 @@ func parseRSS1(data []byte, read *db) (*Feed, error) {
 			if err != nil {
 				return nil, err
 			}
+		} else if item.PubDate != "" {
+			next.Date, err = parseTime(item.PubDate)
+			if err != nil {
+				return nil, err
+			}
 		}
 		next.ID = item.ID
 		next.Read = false
@@ -126,7 +131,8 @@ type rss1_0Item struct {
 	Title   string   `xml:"title"`
 	Content string   `xml:"description"`
 	Link    string   `xml:"link"`
-	Date    string   `xml:"pubDate"`
+	PubDate string   `xml:"pubDate"`
+	Date    string   `xml:"date"`
 	ID      string   `xml:"guid"`
 }
 

--- a/rss 2.0.go
+++ b/rss 2.0.go
@@ -87,6 +87,11 @@ func parseRSS2(data []byte, read *db) (*Feed, error) {
 			if err != nil {
 				return nil, err
 			}
+		} else if item.PubDate != "" {
+			next.Date, err = parseTime(item.PubDate)
+			if err != nil {
+				return nil, err
+			}
 		}
 		next.ID = item.ID
 		next.Read = false
@@ -126,7 +131,8 @@ type rss2_0Item struct {
 	Title   string   `xml:"title"`
 	Content string   `xml:"description"`
 	Link    string   `xml:"link"`
-	Date    string   `xml:"pubDate"`
+	PubDate    string   `xml:"pubDate"`
+	Date    string   `xml:"date"`
 	ID      string   `xml:"guid"`
 }
 


### PR DESCRIPTION
I added "dc:date" tag support. RSS sometime contains "dc:date" tag as well as "pubDate" tag.
