### PR TITLE
feat: support custom time layouts

### DIFF
--- a/time.go
+++ b/time.go
@@ -5,8 +5,16 @@ import (
 	"time"
 )
 
-func parseTime(s string) (time.Time, error) {
-	formats := []string{
+// TimeLayouts is contains a list of time.Parse() layouts that are used in
+// attempts to convert item.Date and item.PubDate string to time.Time values.
+// The layouts are attempted in ascending order until either time.Parse()
+// does not return an error or all layouts are attempted.
+var TimeLayouts []string = DefaultTimeLayouts()
+
+// DefaultTimeLayouts contains a list of default time.Parse() layouts used to
+// convert item.Date and item.PubDate strings to time.Time values.
+func DefaultTimeLayouts() []string {
+	return []string{
 		"Mon, _2 Jan 2006 15:04:05 MST",
 		"Mon, _2 Jan 2006 15:04:05 -0700",
 		time.ANSIC,
@@ -20,18 +28,20 @@ func parseTime(s string) (time.Time, error) {
 		time.RFC3339,
 		time.RFC3339Nano,
 	}
+}
 
+func parseTime(s string) (time.Time, error) {
 	s = strings.TrimSpace(s)
-	
+
 	var e error
 	var t time.Time
-	
-	for _, format := range formats {
-		t, e = time.Parse(format, s)
+
+	for _, layout := range TimeLayouts {
+		t, e = time.Parse(layout, s)
 		if e == nil {
 			return t, e
 		}
 	}
-	
+
 	return time.Time{}, e
 }

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,52 @@
+package rss
+
+import (
+	"testing"
+	"time"
+)
+
+const customLayout = "2006-01-02T15:04Z07:00"
+
+var (
+	timeVal = time.Date(2015, 7, 1, 9, 27, 0, 0, time.UTC)
+)
+
+func TestParseTimeUsingOnlyDefaultLayouts(t *testing.T) {
+	// Positive cases
+	for _, layout := range DefaultTimeLayouts() {
+		s := timeVal.Format(layout)
+		if tv, err := parseTime(s); err != nil || !tv.Equal(timeVal) {
+			t.Error("expected no err and times to equal, got err %v and time value %v", err, tv)
+		}
+	}
+
+	// Negative cases
+	if _, err := parseTime(""); err == nil {
+		t.Error("expected err, got none")
+	}
+	if _, err := parseTime("abc"); err == nil {
+		t.Error("expected err, got none")
+	}
+	custom := timeVal.Format(customLayout)
+	if _, err := parseTime(custom); err == nil {
+		t.Error("expected err, got none")
+	}
+}
+
+func TestParseTimeUsingCustomLayoutsPrepended(t *testing.T) {
+	TimeLayouts = append([]string{customLayout}, DefaultTimeLayouts()...)
+	custom := timeVal.Format(customLayout)
+	if tv, err := parseTime(custom); err != nil || !tv.Equal(timeVal) {
+		t.Error("expected no err and times to equal, got err %v and time value %v", err, tv)
+	}
+	TimeLayouts = DefaultTimeLayouts()
+}
+
+func TestParseTimeUsingCustomLayoutsAppended(t *testing.T) {
+	TimeLayouts = append(DefaultTimeLayouts(), customLayout)
+	custom := timeVal.Format(customLayout)
+	if tv, err := parseTime(custom); err != nil || !tv.Equal(timeVal) {
+		t.Error("expected no err and times to equal, got err %v and time value %v", err, tv)
+	}
+	TimeLayouts = DefaultTimeLayouts()
+}


### PR DESCRIPTION
This implementation minimizes the amount of change required to support
custom time layouts. The alternative would be to add custom time layouts
as parameter to the various fetch methods. Adding an additional context
parameter would change the current API.