### PR TITLE
Add another time format

### DIFF
--- a/time.go
+++ b/time.go
@@ -22,6 +22,7 @@ var TimeLayouts = []string{
 	time.RFC1123Z,
 	time.RFC3339,
 	time.RFC3339Nano,
+	"1/2/2006 3:04:05 PM",
 }
 
 func parseTime(s string) (time.Time, error) {


### PR DESCRIPTION
Previously the feed at http://www.gatesnotes.com/home/rss was not accepted, now it is.

I'm not entirely sure you want to accept this, as the format is ambiguous: it uses month/day/year but could equally well be day/month/year.

Another option would be to still accept feeds with times that cannot be parsed, but replace the date with a null value.