### PR TITLE
Allow getting content without images, fix formatting

### DIFF
--- a/content_test.go
+++ b/content_test.go
@@ -1,0 +1,27 @@
+package rss
+
+import "testing"
+
+func TestShouldStripImageFromContent(t *testing.T) {
+	var data = []struct {
+		orig string
+		exp  string
+	}{
+		{"Some Content<img src=\"http://link/to/image.jpg\"/>", "Some Content"},
+		{"Before <img src=\"http://link/to/image.jpg\"/> After", "Before  After"},
+		{"<img src=\"http://link/to/image.jpg\"/>Image was at the beginning.", "Image was at the beginning."},
+		{"Image had no <img src=\"http://link/to/image.jpg\"/>slash at the end of the tag", "Image had no slash at the end of the tag"},
+		{"All <img src=\"http://link/to/image.jpg\"/>images <img src=\"http://link/to/image.jpg\"/>are <img src=\"http://link/to/image.jpg\"/>gone", "All images are gone"},
+	}
+
+	for _, d := range data {
+		it := Item{Title: "Title", Content: d.orig}
+
+		c := it.RawContent()
+
+		if c != d.exp {
+			t.Errorf("Raw Content expected: %v, got %v", d.exp, c)
+		}
+	}
+
+}

--- a/rss.go
+++ b/rss.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -83,16 +84,16 @@ func FetchByFunc(fetchFunc FetchFunc, url string) (*Feed, error) {
 
 // Feed is the top-level structure.
 type Feed struct {
-	Nickname    string    `json:"nickname"`// This is not set by the package, but could be helpful.
-	Title       string    `json:"title"`
-	Description string    `json:"description"`
-	Link        string    `json:"link"`// Link to the creator's website.
-	UpdateURL   string    `json:"updateurl"`// URL of the feed itself.
-	Image       *Image    `json:"image"`// Feed icon.
-	Items       []*Item   `json:"items"`
-	ItemMap     map[string]struct{} `json:"itemmap"`// Used in checking whether an item has been seen before.
-	Refresh     time.Time           `json:"refresh"`// Earliest time this feed should next be checked.
-	Unread      uint32              `json:"unread"`// Number of unread items. Used by aggregators.
+	Nickname    string              `json:"nickname"` // This is not set by the package, but could be helpful.
+	Title       string              `json:"title"`
+	Description string              `json:"description"`
+	Link        string              `json:"link"`      // Link to the creator's website.
+	UpdateURL   string              `json:"updateurl"` // URL of the feed itself.
+	Image       *Image              `json:"image"`     // Feed icon.
+	Items       []*Item             `json:"items"`
+	ItemMap     map[string]struct{} `json:"itemmap"` // Used in checking whether an item has been seen before.
+	Refresh     time.Time           `json:"refresh"` // Earliest time this feed should next be checked.
+	Unread      uint32              `json:"unread"`  // Number of unread items. Used by aggregators.
 }
 
 // Update fetches any new items and updates f.
@@ -173,18 +174,24 @@ func (f *Feed) String() string {
 
 // Item represents a single story.
 type Item struct {
-	Title      string        `json:"title"`
-	Summary    string        `json:"summary"`
-	Content    string        `json:"content"`
-	Link       string        `json:"link"`
-	Date       time.Time     `json:"date"`
-	ID         string        `json:"id"`
-	Enclosures []*Enclosure  `json:"enclosures"`
-	Read       bool          `json:"read"`
+	Title      string       `json:"title"`
+	Summary    string       `json:"summary"`
+	Content    string       `json:"content"`
+	Link       string       `json:"link"`
+	Date       time.Time    `json:"date"`
+	ID         string       `json:"id"`
+	Enclosures []*Enclosure `json:"enclosures"`
+	Read       bool         `json:"read"`
 }
 
 func (i *Item) String() string {
 	return i.Format(0)
+}
+
+// RawContent returns an item's content with all <img> tags removed.
+func (i Item) RawContent() string {
+	re := regexp.MustCompile("<img([\\w\\W]+?)/>")
+	return re.ReplaceAllLiteralString(i.Content, "")
 }
 
 func (i *Item) Format(indent int) string {
@@ -216,10 +223,10 @@ func (i *Item) Format(indent int) string {
 }
 
 type Enclosure struct {
-	Url    string    `json:"url"`
-	Type   string    `json:"type"`
-	Rel    string    `json:"rel"`
-	Length int       `json:"length"`
+	Url    string `json:"url"`
+	Type   string `json:"type"`
+	Rel    string `json:"rel"`
+	Length int    `json:"length"`
 }
 
 func (e *Enclosure) Get() (io.ReadCloser, error) {
@@ -236,10 +243,10 @@ func (e *Enclosure) Get() (io.ReadCloser, error) {
 }
 
 type Image struct {
-	Title  string    `json:"title"`
-	Url    string    `json:"url"`
-	Height uint32    `json:"height"`
-	Width  uint32    `json:"width"`
+	Title  string `json:"title"`
+	Url    string `json:"url"`
+	Height uint32 `json:"height"`
+	Width  uint32 `json:"width"`
 }
 
 func (i *Image) Get() (io.ReadCloser, error) {


### PR DESCRIPTION
This allows to get rss.Item's content without `<img/>` tags, which is perfect for non-browser RSS clients.

Also the code has been autoformatted with `gofmt` via Spacemacs.