### PR TITLE
Enclosure fix

### DIFF
--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -170,9 +170,9 @@ type rss2_0Item struct {
 
 type rss2_0Enclosure struct {
 	XMLName xml.Name `xml:"enclosure"`
-	Url     string   `xml:"url"`
-	Type    string   `xml:"type"`
-	Length  int      `xml:"length"`
+	Url     string   `xml:"url,attr"`
+	Type    string   `xml:"type,attr"`
+	Length  int      `xml:"length,attr"`
 }
 
 func (r *rss2_0Enclosure) Enclosure() *Enclosure {

--- a/rss_test.go
+++ b/rss_test.go
@@ -36,7 +36,7 @@ func TestParseTitle(t *testing.T) {
 func TestEnclosure(t *testing.T) {
 	tests := map[string][]*Enclosure{
 		"rss_1.0":  []*Enclosure{{Url: "http://foo.bar/baz.mp3", Type: "audio/mpeg", Length: 65535}},
-		"rss_2.0":  []*Enclosure{{Url: "http://example.com/file.mp3", Type: "audio/mpeg", Length: 65535}},
+		"rss_2.0":  []*Enclosure{{Url: "http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg", Type: "image/jpeg", Length: 3123}},
 		"atom_1.0": []*Enclosure{{Url: "http://example.org/audio.mp3", Type: "audio/mpeg", Length: 1234}},
 	}
 

--- a/rss_test.go
+++ b/rss_test.go
@@ -35,9 +35,10 @@ func TestParseTitle(t *testing.T) {
 
 func TestEnclosure(t *testing.T) {
 	tests := map[string][]*Enclosure{
-		"rss_1.0":  []*Enclosure{{Url: "http://foo.bar/baz.mp3", Type: "audio/mpeg", Length: 65535}},
-		"rss_2.0":  []*Enclosure{{Url: "http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg", Type: "image/jpeg", Length: 3123}},
-		"atom_1.0": []*Enclosure{{Url: "http://example.org/audio.mp3", Type: "audio/mpeg", Length: 1234}},
+		"rss_1.0":   []*Enclosure{{Url: "http://foo.bar/baz.mp3", Type: "audio/mpeg", Length: 65535}},
+		"rss_2.0":   []*Enclosure{{Url: "http://example.com/file.mp3", Type: "audio/mpeg", Length: 65535}},
+		"rss_2.0-1": []*Enclosure{{Url: "http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg", Type: "image/jpeg", Length: 3123}},
+		"atom_1.0":  []*Enclosure{{Url: "http://example.org/audio.mp3", Type: "audio/mpeg", Length: 1234}},
 	}
 
 	for test, want := range tests {

--- a/testdata/rss_2.0-1_enclosure
+++ b/testdata/rss_2.0-1_enclosure
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">     
+    <channel>      
+        <title>ዜና - የአሜሪካ ድምፅ</title>     
+        <link>http://amharic.voanews.com/archive/news/latest/3167/3167.html</link>
+        <description>The Voice of America broadcasts daily radio programs to Ethiopia in Amharic.  Each program features the latest news, in-depth reports on issues in the news from VOA correspondents and feature reports. 
+የፕሮግራም መግለጫ
+ወደ 98 ሚሊየን የሚጠጋ ሕዝብ ባላት ኢትዮጵያ አማርኛ ብሔራዊ</description>
+        <image>
+            <url>http://www.voanews.com/img/voa/rssLogo_VOA.gif</url>
+            <title>ዜና - የአሜሪካ ድምፅ</title>
+            <link>http://amharic.voanews.com/archive/news/latest/3167/3167.html</link>
+        </image>
+        <language>am</language>
+        <copyright>2012 - VOA</copyright>   
+        <ttl>60</ttl>        
+        <lastBuildDate>Sun, 15 May 2016 13:53:13 +0300</lastBuildDate> 
+        <generator>Pangea CMS – VOA</generator>        
+        <atom:link href="http://amharic.voanews.com/api/zt$gteitjt" rel="self" type="application/rss+xml" />
+    		<item>
+            <title>አሜሪካ ለኢትዮጵያ ተጨማሪ እርዳታ ሰጠች</title>
+            <description>ዩናይትድ ስቴትስ በድርቅ ለተጎዱ ኢትዮጵያዊያን መርጃ የሚሆን የ128 ሚሊየን ዶላር ተጨማሪ ድጋፍ ሰጥታለች።</description>
+            <link>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html</link> 
+            <guid>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html</guid>            
+            <pubDate>Sat, 14 May 2016 18:39:34 +0300</pubDate>
+            <category>ዜና</category><category>ኢትዮጵያ</category><author>noreply@voanews.com (እስክንድር ፍሬው)</author><comments>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html#relatedInfoContainer</comments><enclosure url="http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg" length="3123" type="image/jpeg"/>
+        </item>		
+        </channel></rss>

--- a/testdata/rss_2.0_enclosure
+++ b/testdata/rss_2.0_enclosure
@@ -1,27 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">     
-    <channel>      
-        <title>ዜና - የአሜሪካ ድምፅ</title>     
-        <link>http://amharic.voanews.com/archive/news/latest/3167/3167.html</link>
-        <description>The Voice of America broadcasts daily radio programs to Ethiopia in Amharic.  Each program features the latest news, in-depth reports on issues in the news from VOA correspondents and feature reports. 
-የፕሮግራም መግለጫ
-ወደ 98 ሚሊየን የሚጠጋ ሕዝብ ባላት ኢትዮጵያ አማርኛ ብሔራዊ</description>
-        <image>
-            <url>http://www.voanews.com/img/voa/rssLogo_VOA.gif</url>
-            <title>ዜና - የአሜሪካ ድምፅ</title>
-            <link>http://amharic.voanews.com/archive/news/latest/3167/3167.html</link>
-        </image>
-        <language>am</language>
-        <copyright>2012 - VOA</copyright>   
-        <ttl>60</ttl>        
-        <lastBuildDate>Sun, 15 May 2016 13:53:13 +0300</lastBuildDate> 
-        <generator>Pangea CMS – VOA</generator>        
-        <atom:link href="http://amharic.voanews.com/api/zt$gteitjt" rel="self" type="application/rss+xml" />
-    		<item>
-            <title>አሜሪካ ለኢትዮጵያ ተጨማሪ እርዳታ ሰጠች</title>
-            <description>ዩናይትድ ስቴትስ በድርቅ ለተጎዱ ኢትዮጵያዊያን መርጃ የሚሆን የ128 ሚሊየን ዶላር ተጨማሪ ድጋፍ ሰጥታለች።</description>
-            <link>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html</link> 
-            <guid>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html</guid>            
-            <pubDate>Sat, 14 May 2016 18:39:34 +0300</pubDate>
-            <category>ዜና</category><category>ኢትዮጵያ</category><author>noreply@voanews.com (እስክንድር ፍሬው)</author><comments>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html#relatedInfoContainer</comments><enclosure url="http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg" length="3123" type="image/jpeg"/>
-        </item>		
-        </channel></rss>
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+ <title>RSS Title</title>
+ <description>This is an example of an RSS feed</description>
+ <link>http://www.someexamplerssdomain.com/main.html</link>
+ <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000</lastBuildDate>
+ <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+ <ttl>1800</ttl>
+
+ <item>
+  <title>Example entry</title>
+  <description>Here is some text containing an interesting
+description.</description>
+  <link>http://www.wikipedia.org/</link>
+  <guid>unique string per item</guid>
+  <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+  <enclosure url="http://example.com/file.mp3" length="65535" type="audio/mpeg" />
+ </item>
+
+</channel>
+</rss>

--- a/testdata/rss_2.0_enclosure
+++ b/testdata/rss_2.0_enclosure
@@ -1,22 +1,27 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
-<channel>
- <title>RSS Title</title>
- <description>This is an example of an RSS feed</description>
- <link>http://www.someexamplerssdomain.com/main.html</link>
- <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000</lastBuildDate>
- <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
- <ttl>1800</ttl>
-
- <item>
-  <title>Example entry</title>
-  <description>Here is some text containing an interesting
-description.</description>
-  <link>http://www.wikipedia.org/</link>
-  <guid>unique string per item</guid>
-  <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
-  <enclosure url="http://example.com/file.mp3" length="65535" type="audio/mpeg" />
- </item>
-
-</channel>
-</rss>
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">     
+    <channel>      
+        <title>ዜና - የአሜሪካ ድምፅ</title>     
+        <link>http://amharic.voanews.com/archive/news/latest/3167/3167.html</link>
+        <description>The Voice of America broadcasts daily radio programs to Ethiopia in Amharic.  Each program features the latest news, in-depth reports on issues in the news from VOA correspondents and feature reports. 
+የፕሮግራም መግለጫ
+ወደ 98 ሚሊየን የሚጠጋ ሕዝብ ባላት ኢትዮጵያ አማርኛ ብሔራዊ</description>
+        <image>
+            <url>http://www.voanews.com/img/voa/rssLogo_VOA.gif</url>
+            <title>ዜና - የአሜሪካ ድምፅ</title>
+            <link>http://amharic.voanews.com/archive/news/latest/3167/3167.html</link>
+        </image>
+        <language>am</language>
+        <copyright>2012 - VOA</copyright>   
+        <ttl>60</ttl>        
+        <lastBuildDate>Sun, 15 May 2016 13:53:13 +0300</lastBuildDate> 
+        <generator>Pangea CMS – VOA</generator>        
+        <atom:link href="http://amharic.voanews.com/api/zt$gteitjt" rel="self" type="application/rss+xml" />
+    		<item>
+            <title>አሜሪካ ለኢትዮጵያ ተጨማሪ እርዳታ ሰጠች</title>
+            <description>ዩናይትድ ስቴትስ በድርቅ ለተጎዱ ኢትዮጵያዊያን መርጃ የሚሆን የ128 ሚሊየን ዶላር ተጨማሪ ድጋፍ ሰጥታለች።</description>
+            <link>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html</link> 
+            <guid>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html</guid>            
+            <pubDate>Sat, 14 May 2016 18:39:34 +0300</pubDate>
+            <category>ዜና</category><category>ኢትዮጵያ</category><author>noreply@voanews.com (እስክንድር ፍሬው)</author><comments>http://amharic.voanews.com/a/us-give-more-aid-to-ethiopia-to-address-crisis/3330430.html#relatedInfoContainer</comments><enclosure url="http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg" length="3123" type="image/jpeg"/>
+        </item>		
+        </channel></rss>


### PR DESCRIPTION
Fixes parsing failures on http://amharic.voanews.com/api/zt$gteitjt

The enclosure attributes fields need to be marked as `attr`. Updated the test files to test for this issue.