### PR TITLE
Added more time layouts to time.go to parse more pubDate variations

### DIFF
--- a/time.go
+++ b/time.go
@@ -12,6 +12,10 @@ import (
 var TimeLayouts = []string{
 	"Mon, _2 Jan 2006 15:04:05 MST",
 	"Mon, _2 Jan 2006 15:04:05 -0700",
+	"_2 Jan 2006 15:04:05 MST",
+	"_2 Jan 2006 15:04:05 -0700",
+	"2006-01-02 15:04:05",
+	"Jan _2, 2006 15:04 PM MST",
 	time.ANSIC,
 	time.UnixDate,
 	time.RubyDate,


### PR DESCRIPTION
Time layouts array is not exhaustive for diff time str in pubDate. Added a few more variants.

The parsing should not fail, if unable to parse the time IMO.