### PR TITLE
Allow calling Update() for unmarshalled rss.Feed

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -44,7 +44,7 @@ func CacheParsedItemIDs(flag bool) (didCache bool) {
 
 type FetchFunc func(url string) (resp *http.Response, err error)
 
-func DefaultFetchFunc(url string) (resp *http.Response, err error) {
+var DefaultFetchFunc = func(url string) (resp *http.Response, err error) {
 	client := http.DefaultClient
 	return client.Get(url)
 }

--- a/rss_test.go
+++ b/rss_test.go
@@ -2,6 +2,7 @@ package rss
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -92,9 +93,18 @@ func TestFeedUnmarshalUpdate(t *testing.T) {
 	var unmarshalledFeed Feed
 	err = json.Unmarshal(jsonBlob, &unmarshalledFeed)
 
+	var defaultFetchFuncCalled = 0
+	DefaultFetchFunc = func(url string) (resp *http.Response, err error) {
+		defaultFetchFuncCalled++
+		return nil, errors.New("No network in test")
+	}
+
 	err = unmarshalledFeed.Update()
 	if err != nil {
-		t.Logf("Expected failure updating via http for testadata: %v", err)
+		t.Logf("Expected failure updating via http in test: %v", err)
+	}
+	if defaultFetchFuncCalled < 1 {
+		t.Error("DefaultFetchFunc was not called during Update()")
 	}
 
 	err = unmarshalledFeed.UpdateByFunc(fetch2)

--- a/testdata/rssupdate-1
+++ b/testdata/rssupdate-1
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+ <title>RSS Title</title>
+ <description>This is an example of an RSS feed</description>
+ <link>http://www.someexamplerssdomain.com/main.html</link>
+ <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000</lastBuildDate>
+ <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+ <ttl>-1</ttl>
+
+ <item>
+  <title>Example entry</title>
+  <description>Here is some text containing an interesting
+description.</description>
+  <link>http://www.wikipedia.org/</link>
+  <guid>unique string per item:update</guid>
+  <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+ </item>
+
+</channel>
+</rss>

--- a/testdata/rssupdate-2
+++ b/testdata/rssupdate-2
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+ <title>RSS Title</title>
+ <description>This is an example of an RSS feed</description>
+ <link>http://www.someexamplerssdomain.com/main.html</link>
+ <lastBuildDate>Mon, 06 Sep 2016 00:01:00 +0000</lastBuildDate>
+ <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+ <ttl>1800</ttl>
+
+ <item>
+  <title>Example entry after update</title>
+  <description>Here is some text containing an interesting
+description.</description>
+  <link>http://www.wikipedia.org/</link>
+  <guid>unique string per item:update-2</guid>
+  <pubDate>Mon, 06 Sep 2015 16:45:00 +0000</pubDate>
+ </item>
+
+ <item>
+  <title>Example entry</title>
+  <description>Here is some text containing an interesting
+description.</description>
+  <link>http://www.wikipedia.org/</link>
+  <guid>unique string per item:update</guid>
+  <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+ </item>
+
+</channel>
+</rss>


### PR DESCRIPTION
Feed.Update() calls member func, which is nil for unmarshalled Feed.
Use DefaultFetchFunc in such case, and also add UpdateByFunc just
like FetchByFunc.