### PR TITLE
RSS2 content enclosure properties are xml attributes, not tags

### DIFF
--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -174,9 +174,9 @@ type rss2_0Item struct {
 
 type rss2_0Enclosure struct {
 	XMLName xml.Name `xml:"enclosure"`
-	Url     string   `xml:"url"`
-	Type    string   `xml:"type"`
-	Length  int      `xml:"length"`
+	Url     string   `xml:"url,attr"`
+	Type    string   `xml:"type,attr"`
+	Length  int      `xml:"length,attr"`
 }
 
 func (r *rss2_0Enclosure) Enclosure() *Enclosure {


### PR DESCRIPTION
This partially reverts c178ee88ce34f8b2482accfd9e82dcaf3f4c7b34

This fixes unit test TestEnclosure