### PR TITLE
Handle two-digit years when parsing dates

### DIFF
--- a/time.go
+++ b/time.go
@@ -11,11 +11,16 @@ import (
 // does not return an error or all layouts are attempted.
 var TimeLayouts = []string{
 	"Mon, _2 Jan 2006 15:04:05 MST",
+	"Mon, _2 Jan 06 15:04:05 MST",
 	"Mon, _2 Jan 2006 15:04:05 -0700",
+	"Mon, _2 Jan 06 15:04:05 -0700",
 	"_2 Jan 2006 15:04:05 MST",
+	"_2 Jan 06 15:04:05 MST",
 	"_2 Jan 2006 15:04:05 -0700",
+	"_2 Jan 06 15:04:05 -0700",
 	"2006-01-02 15:04:05",
 	"Jan _2, 2006 15:04 PM MST",
+	"Jan _2, 06 15:04 PM MST",
 	time.ANSIC,
 	time.UnixDate,
 	time.RubyDate,

--- a/time_test.go
+++ b/time_test.go
@@ -51,3 +51,11 @@ func TestParseTimeUsingCustomLayoutsAppended(t *testing.T) {
 	}
 	TimeLayouts = originalLayouts
 }
+
+func TestParseWithTwoDigitYear(t *testing.T) {
+	s := "Sun, 18 Dec 16 18:25:00 +0100"
+	if tv, err := parseTime(s); err != nil || tv.Year() != 2016 {
+		t.Error("expected no err and year to be 2016, got err %v, and year %v", err, tv.Year())
+	}
+}
+


### PR DESCRIPTION
According to the only RSS 2.0 spec I found (http://cyber.harvard.edu/rss/rss.html):

> All date-times in RSS conform to the Date and Time Specification of RFC 822, with the exception that the year may be expressed with two characters or four characters (four preferred)

Of course, the first RSS feed I tried out was formatted this way:)