### PR TITLE
RFC 822 allows Z as the time zone

### DIFF
--- a/time.go
+++ b/time.go
@@ -10,6 +10,7 @@ import (
 // The layouts are attempted in ascending order until either time.Parse()
 // does not return an error or all layouts are attempted.
 var TimeLayouts = []string{
+	"Mon, _2 Jan 2006 15:04:05 Z",
 	"Mon, _2 Jan 2006 15:04:05 MST",
 	"Mon, _2 Jan 06 15:04:05 MST",
 	"Mon, _2 Jan 2006 15:04:05 -0700",


### PR DESCRIPTION
[RFC 822](https://www.ietf.org/rfc/rfc822.txt) allows `Z` as the time zone:

> 5.2.  SEMANTICS
> [...]
> Time zone may be indicated in several ways.  "UT" is Univer-
> sal  Time  (formerly called "Greenwich Mean Time"); "GMT" is per-
> mitted as a reference to Universal Time.  The  military  standard
> uses  a  single  character for each zone.  "Z" is Universal Time.

I've added `"Mon, _2 Jan 2006 15:04:05 Z"` to the `TimeLayouts` to support such feeds.