### PR TITLE
cleaned warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ type Item struct {
 
 type Image struct {
 	Title   string
-	Url     string
+	URL     string
 	Height  uint32
 	Width   uint32
 }

--- a/atom.go
+++ b/atom.go
@@ -30,7 +30,7 @@ func parseAtom(data []byte) (*Feed, error) {
 	out.Refresh = time.Now().Add(10 * time.Minute)
 
 	if feed.Items == nil {
-		return nil, fmt.Errorf("Error: no feeds found in %q.", string(data))
+		return nil, fmt.Errorf("no feeds found in %q", string(data))
 	}
 
 	out.Items = make([]*Item, 0, len(feed.Items))
@@ -60,7 +60,7 @@ func parseAtom(data []byte) (*Feed, error) {
 				next.Link = link.Href
 			} else {
 				next.Enclosures = append(next.Enclosures, &Enclosure{
-					Url:    link.Href,
+					URL:    link.Href,
 					Type:   link.Type,
 					Length: link.Length,
 				})
@@ -121,7 +121,7 @@ type atomItem struct {
 type atomImage struct {
 	XMLName xml.Name `xml:"image"`
 	Title   string   `xml:"title"`
-	Url     string   `xml:"url"`
+	URL     string   `xml:"url"`
 	Height  int      `xml:"height"`
 	Width   int      `xml:"width"`
 }
@@ -136,7 +136,7 @@ type atomLink struct {
 func (a *atomImage) Image() *Image {
 	out := new(Image)
 	out.Title = a.Title
-	out.Url = a.Url
+	out.URL = a.URL
 	out.Height = uint32(a.Height)
 	out.Width = uint32(a.Width)
 	return out

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Package RSS is a small library for simplifying the parsing of RSS and Atom feeds.
+Package rss is a small library for simplifying the parsing of RSS and Atom feeds.
 
 The package could do with more testing, but it conforms to the RSS 1.0, 2.0, and Atom 1.0
 specifications, to the best of my ability. I've tested it with about 15 different feeds,
@@ -58,7 +58,7 @@ type Item struct {
 
 type Image struct {
 	Title   string
-	Url     string
+	URL     string
 	Height  uint32
 	Width   uint32
 }

--- a/rss_1.0.go
+++ b/rss_1.0.go
@@ -19,7 +19,7 @@ func parseRSS1(data []byte) (*Feed, error) {
 		return nil, err
 	}
 	if feed.Channel == nil {
-		return nil, fmt.Errorf("Error: no channel found in %q.", string(data))
+		return nil, fmt.Errorf("no channel found in %q", string(data))
 	}
 
 	channel := feed.Channel
@@ -57,7 +57,7 @@ func parseRSS1(data []byte) (*Feed, error) {
 	}
 
 	if feed.Items == nil {
-		return nil, fmt.Errorf("Error: no feeds found in %q.", string(data))
+		return nil, fmt.Errorf("no feeds found in %q", string(data))
 	}
 
 	out.Items = make([]*Item, 0, len(feed.Items))
@@ -151,14 +151,14 @@ type rss1_0Item struct {
 
 type rss1_0Enclosure struct {
 	XMLName xml.Name `xml:"enclosure"`
-	Url     string   `xml:"resource,attr"`
+	URL     string   `xml:"resource,attr"`
 	Type    string   `xml:"type,attr"`
 	Length  uint     `xml:"length,attr"`
 }
 
 func (r *rss1_0Enclosure) Enclosure() *Enclosure {
 	out := new(Enclosure)
-	out.Url = r.Url
+	out.URL = r.URL
 	out.Type = r.Type
 	out.Length = r.Length
 	return out
@@ -167,7 +167,7 @@ func (r *rss1_0Enclosure) Enclosure() *Enclosure {
 type rss1_0Image struct {
 	XMLName xml.Name `xml:"image"`
 	Title   string   `xml:"title"`
-	Url     string   `xml:"url"`
+	URL     string   `xml:"url"`
 	Height  int      `xml:"height"`
 	Width   int      `xml:"width"`
 }
@@ -175,7 +175,7 @@ type rss1_0Image struct {
 func (i *rss1_0Image) Image() *Image {
 	out := new(Image)
 	out.Title = i.Title
-	out.Url = i.Url
+	out.URL = i.URL
 	out.Height = uint32(i.Height)
 	out.Width = uint32(i.Width)
 	return out

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -19,7 +19,7 @@ func parseRSS2(data []byte) (*Feed, error) {
 		return nil, err
 	}
 	if feed.Channel == nil {
-		return nil, fmt.Errorf("Error: no channel found in %q.", string(data))
+		return nil, fmt.Errorf("no channel found in %q", string(data))
 	}
 
 	channel := feed.Channel
@@ -62,7 +62,7 @@ func parseRSS2(data []byte) (*Feed, error) {
 	}
 
 	if channel.Items == nil {
-		return nil, fmt.Errorf("Error: no feeds found in %q.", string(data))
+		return nil, fmt.Errorf("no feeds found in %q", string(data))
 	}
 
 	out.Items = make([]*Item, 0, len(channel.Items))
@@ -165,14 +165,14 @@ type rss2_0Item struct {
 
 type rss2_0Enclosure struct {
 	XMLName xml.Name `xml:"enclosure"`
-	Url     string   `xml:"url,attr"`
+	URL     string   `xml:"url,attr"`
 	Type    string   `xml:"type,attr"`
 	Length  uint     `xml:"length,attr"`
 }
 
 func (r *rss2_0Enclosure) Enclosure() *Enclosure {
 	out := new(Enclosure)
-	out.Url = r.Url
+	out.URL = r.URL
 	out.Type = r.Type
 	out.Length = r.Length
 	return out
@@ -181,7 +181,7 @@ func (r *rss2_0Enclosure) Enclosure() *Enclosure {
 type rss2_0Image struct {
 	XMLName xml.Name `xml:"image"`
 	Title   string   `xml:"title"`
-	Url     string   `xml:"url"`
+	URL     string   `xml:"url"`
 	Height  int      `xml:"height"`
 	Width   int      `xml:"width"`
 }
@@ -189,7 +189,7 @@ type rss2_0Image struct {
 func (i *rss2_0Image) Image() *Image {
 	out := new(Image)
 	out.Title = i.Title
-	out.Url = i.Url
+	out.URL = i.URL
 	out.Height = uint32(i.Height)
 	out.Width = uint32(i.Width)
 	return out

--- a/rss_default.go
+++ b/rss_default.go
@@ -4,4 +4,5 @@ package rss
 
 const debug = false
 
+// DATE is a constant date string.
 const DATE = "15:04:05 MST 02/01/2006"

--- a/rss_test.go
+++ b/rss_test.go
@@ -39,10 +39,10 @@ func TestParseTitle(t *testing.T) {
 
 func TestEnclosure(t *testing.T) {
 	tests := map[string]Enclosure{
-		"rss_1.0":   Enclosure{Url: "http://foo.bar/baz.mp3", Type: "audio/mpeg", Length: 65535},
-		"rss_2.0":   Enclosure{Url: "http://example.com/file.mp3", Type: "audio/mpeg", Length: 65535},
-		"rss_2.0-1": Enclosure{Url: "http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg", Type: "image/jpeg", Length: 3123},
-		"atom_1.0":  Enclosure{Url: "http://example.org/audio.mp3", Type: "audio/mpeg", Length: 1234},
+		"rss_1.0":   Enclosure{URL: "http://foo.bar/baz.mp3", Type: "audio/mpeg", Length: 65535},
+		"rss_2.0":   Enclosure{URL: "http://example.com/file.mp3", Type: "audio/mpeg", Length: 65535},
+		"rss_2.0-1": Enclosure{URL: "http://gdb.voanews.com/6C49CA6D-C18D-414D-8A51-2B7042A81010_cx0_cy29_cw0_w800_h450.jpg", Type: "image/jpeg", Length: 3123},
+		"atom_1.0":  Enclosure{URL: "http://example.org/audio.mp3", Type: "audio/mpeg", Length: 1234},
 	}
 
 	for test, want := range tests {


### PR DESCRIPTION
I've cleaned some warnings the Go tools complain about:

* `Url` should be `URL`
* error messages should start with a lower case word and not end with punctuation
* exported funcs must have a doc comment

Please check if these changes are acceptable, especially the API changing rename to `URL`.