### PR TITLE
implemented support for RSS <content:encoded>

### DIFF
--- a/atom_test.go
+++ b/atom_test.go
@@ -1,0 +1,54 @@
+package rss
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestParseAtomTitle(t *testing.T) {
+	tests := map[string]string{
+		"atom_1.0":           "Titel des Weblogs",
+		"atom_1.0_enclosure": "Titel des Weblogs",
+		"atom_1.0-1":         "Golem.de",
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if feed.Title != want {
+			t.Fatalf("%s: expected %s, got %s", test, want, feed.Title)
+		}
+	}
+}
+
+func TestParseAtomContent(t *testing.T) {
+	tests := map[string]string{
+		"atom_1.0":           "Volltext des Weblog-Eintrags",
+		"atom_1.0_enclosure": "Volltext des Weblog-Eintrags",
+		"atom_1.0-1":         "",
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if feed.Items[0].Content != want {
+			t.Fatalf("%s: expected %s, got %s", test, want, feed.Items[0].Content)
+		}
+	}
+}

--- a/rss_1.0_test.go
+++ b/rss_1.0_test.go
@@ -1,0 +1,28 @@
+package rss
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestParseRSS(t *testing.T) {
+	tests := map[string]string{
+		"rss_1.0": "Golem.de",
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if feed.Title != want {
+			t.Fatalf("%s: expected %s, got %s", test, want, feed.Title)
+		}
+	}
+}

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -154,7 +154,7 @@ type rss2_0Item struct {
 	XMLName     xml.Name          `xml:"item"`
 	Title       string            `xml:"title"`
 	Description string            `xml:"description"`
-	Content     string            `xml:"encoded"`
+	Content     string            `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
 	Category    string            `xml:"category"`
 	Link        string            `xml:"link"`
 	PubDate     string            `xml:"pubDate"`

--- a/rss_2.0_test.go
+++ b/rss_2.0_test.go
@@ -1,0 +1,28 @@
+package rss
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestParseContent(t *testing.T) {
+	tests := map[string]string{
+		"rss_2.0_content_encoded": "<p><a href=\"https://example.com/\">Example.com</a> is an example site.</p>",
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if feed.Items[0].Content != want {
+			t.Fatalf("%s: expected %s, got %s", test, want, feed.Items[0].Content)
+		}
+	}
+}

--- a/testdata/rss_2.0_content_encoded
+++ b/testdata/rss_2.0_content_encoded
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  >
+<channel>
+ <title>RSS Title</title>
+ <description>This is an example of an RSS feed</description>
+ <link>http://www.someexamplerssdomain.com/main.html</link>
+ <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000</lastBuildDate>
+ <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+ <ttl>1800</ttl>
+
+ <item>
+  <title>Example entry</title>
+  <description>Here is some text containing an interesting
+description.</description>
+  <link>http://www.wikipedia.org/</link>
+  <guid>unique string per item</guid>
+  <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
+  <content:encoded><![CDATA[<p><a href="https://example.com/">Example.com</a> is an example site.</p>]]></content:encoded>
+ </item>
+
+</channel>
+</rss>


### PR DESCRIPTION
This should implement https://github.com/SlyMarbo/rss/issues/27 as an element like

    <content:encoded><![CDATA[<p><a href="https://example.com/">Example.com</a> is an example site.</p>]]></content:encoded>

is assigned to `rss2_0Item.Content`.

I am not sure if RSS 1.x and Atom support the RSS Content Module. For now, I've only implemented it for RSS 2.0.

To make working easier in the future, I've also added some tests.