### PR TITLE
accept unparsable dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ type Feed struct {
 }
 
 type Item struct {
-	Title   string
-	Summary string
-	Content string
-	Link    string
-	Date    time.Time
-	ID      string
-	Read    bool
+	Title     string
+	Summary   string
+	Content   string
+	Link      string
+	Date      time.Time
+	DateValid bool
+	ID        string
+	Read      bool
 }
 
 type Image struct {

--- a/atom.go
+++ b/atom.go
@@ -50,9 +50,8 @@ func parseAtom(data []byte) (*Feed, error) {
 		next.Content = item.Content
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
-			if err != nil {
-				fmt.Printf("[w] Item %q has unparsable date: %s\n", item.Title, err)
-				warnings = true
+			if err == nil {
+				item.DateValid = true
 			}
 		}
 		next.ID = item.ID
@@ -110,13 +109,14 @@ type atomFeed struct {
 }
 
 type atomItem struct {
-	XMLName xml.Name   `xml:"entry"`
-	Title   string     `xml:"title"`
-	Summary string     `xml:"summary"`
-	Content string     `xml:"content"`
-	Links   []atomLink `xml:"link"`
-	Date    string     `xml:"updated"`
-	ID      string     `xml:"id"`
+	XMLName   xml.Name   `xml:"entry"`
+	Title     string     `xml:"title"`
+	Summary   string     `xml:"summary"`
+	Content   string     `xml:"content"`
+	Links     []atomLink `xml:"link"`
+	Date      string     `xml:"updated"`
+	DateValid bool
+	ID        string `xml:"id"`
 }
 
 type atomImage struct {

--- a/atom.go
+++ b/atom.go
@@ -51,7 +51,8 @@ func parseAtom(data []byte) (*Feed, error) {
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err != nil {
-				return nil, err
+				fmt.Printf("[w] Item %q has unparsable date: %s\n", item.Title, err)
+				warnings = true
 			}
 		}
 		next.ID = item.ID

--- a/doc.go
+++ b/doc.go
@@ -47,13 +47,14 @@ type Feed struct {
 }
 
 type Item struct {
-	Title   string
-	Summary string
-	Content string
-	Link    string
-	Date    time.Time
-	ID      string
-	Read    bool
+	Title     string
+	Summary   string
+	Content   string
+	Link      string
+	Date      time.Time
+	DateValid bool
+	ID        string
+	Read      bool
 }
 
 type Image struct {

--- a/rss.go
+++ b/rss.go
@@ -203,12 +203,13 @@ func (f *Feed) String() string {
 
 // Item represents a single story.
 type Item struct {
-	Title      string       `json:"title"`
-	Summary    string       `json:"summary"`
-	Content    string       `json:"content"`
-	Category   string       `json:"category"`
-	Link       string       `json:"link"`
-	Date       time.Time    `json:"date"`
+	Title      string    `json:"title"`
+	Summary    string    `json:"summary"`
+	Content    string    `json:"content"`
+	Category   string    `json:"category"`
+	Link       string    `json:"link"`
+	Date       time.Time `json:"date"`
+	DateValid  bool
 	ID         string       `json:"id"`
 	Enclosures []*Enclosure `json:"enclosures"`
 	Read       bool         `json:"read"`

--- a/rss_1.0.go
+++ b/rss_1.0.go
@@ -90,15 +90,13 @@ func parseRSS1(data []byte) (*Feed, error) {
 		next.Link = item.Link
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
-			if err != nil {
-				fmt.Printf("[w] Item %q has unparsable date: %s\n", item.Title, err)
-				warnings = true
+			if err == nil {
+				item.DateValid = true
 			}
 		} else if item.PubDate != "" {
 			next.Date, err = parseTime(item.PubDate)
-			if err != nil {
-				fmt.Printf("[w] Item %q has unparsable pubDate: %s\n", item.Title, err)
-				warnings = true
+			if err == nil {
+				item.DateValid = true
 			}
 		}
 		next.ID = item.ID
@@ -140,13 +138,14 @@ type rss1_0Channel struct {
 }
 
 type rss1_0Item struct {
-	XMLName     xml.Name          `xml:"item"`
-	Title       string            `xml:"title"`
-	Description string            `xml:"description"`
-	Content     string            `xml:"encoded"`
-	Link        string            `xml:"link"`
-	PubDate     string            `xml:"pubDate"`
-	Date        string            `xml:"date"`
+	XMLName     xml.Name `xml:"item"`
+	Title       string   `xml:"title"`
+	Description string   `xml:"description"`
+	Content     string   `xml:"encoded"`
+	Link        string   `xml:"link"`
+	PubDate     string   `xml:"pubDate"`
+	Date        string   `xml:"date"`
+	DateValid   bool
 	ID          string            `xml:"guid"`
 	Enclosures  []rss1_0Enclosure `xml:"enclosure"`
 }

--- a/rss_1.0.go
+++ b/rss_1.0.go
@@ -91,12 +91,14 @@ func parseRSS1(data []byte) (*Feed, error) {
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err != nil {
-				return nil, err
+				fmt.Printf("[w] Item %q has unparsable date: %s\n", item.Title, err)
+				warnings = true
 			}
 		} else if item.PubDate != "" {
 			next.Date, err = parseTime(item.PubDate)
 			if err != nil {
-				return nil, err
+				fmt.Printf("[w] Item %q has unparsable pubDate: %s\n", item.Title, err)
+				warnings = true
 			}
 		}
 		next.ID = item.ID

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -96,15 +96,13 @@ func parseRSS2(data []byte) (*Feed, error) {
 		next.Link = item.Link
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
-			if err != nil {
-				fmt.Printf("[w] Item %q has unparsable date: %s\n", item.Title, err)
-				warnings = true
+			if err == nil {
+				item.DateValid = true
 			}
 		} else if item.PubDate != "" {
 			next.Date, err = parseTime(item.PubDate)
-			if err != nil {
-				fmt.Printf("[w] Item %q has unparsable pubDate: %s\n", item.Title, err)
-				warnings = true
+			if err == nil {
+				item.DateValid = true
 			}
 		}
 		next.ID = item.ID
@@ -153,14 +151,15 @@ type rss2_0Link struct {
 }
 
 type rss2_0Item struct {
-	XMLName     xml.Name          `xml:"item"`
-	Title       string            `xml:"title"`
-	Description string            `xml:"description"`
-	Content     string            `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
-	Category    string            `xml:"category"`
-	Link        string            `xml:"link"`
-	PubDate     string            `xml:"pubDate"`
-	Date        string            `xml:"date"`
+	XMLName     xml.Name `xml:"item"`
+	Title       string   `xml:"title"`
+	Description string   `xml:"description"`
+	Content     string   `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
+	Category    string   `xml:"category"`
+	Link        string   `xml:"link"`
+	PubDate     string   `xml:"pubDate"`
+	Date        string   `xml:"date"`
+	DateValid   bool
 	ID          string            `xml:"guid"`
 	Enclosures  []rss2_0Enclosure `xml:"enclosure"`
 }

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -97,12 +97,14 @@ func parseRSS2(data []byte) (*Feed, error) {
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err != nil {
-				return nil, err
+				fmt.Printf("[w] Item %q has unparsable date: %s\n", item.Title, err)
+				warnings = true
 			}
 		} else if item.PubDate != "" {
 			next.Date, err = parseTime(item.PubDate)
 			if err != nil {
-				return nil, err
+				fmt.Printf("[w] Item %q has unparsable pubDate: %s\n", item.Title, err)
+				warnings = true
 			}
 		}
 		next.ID = item.ID

--- a/rss_2.0_test.go
+++ b/rss_2.0_test.go
@@ -98,5 +98,8 @@ func TestParseItemDateFailure(t *testing.T) {
 		if fmt.Sprintf("%s", feed.Items[1].Date) != want {
 			t.Fatalf("%s: expected %q, got %q", test, want, feed.Items[1].Date)
 		}
+		if feed.Items[1].DateValid {
+			t.Fatalf("%s: expected %t, got %t", test, false, feed.Items[1].DateValid)
+		}
 	}
 }

--- a/rss_2.0_test.go
+++ b/rss_2.0_test.go
@@ -1,10 +1,36 @@
 package rss
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 )
 
+func TestParseItemLen(t *testing.T) {
+	tests := map[string]int{
+		"rss_2.0":                 2,
+		"rss_2.0_content_encoded": 1,
+		"rss_2.0_enclosure":       1,
+		"rss_2.0-1":               4,
+		"rss_2.0-1_enclosure":     1,
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if len(feed.Items) != want {
+			t.Fatalf("%s: expected %q, got %q", test, want, len(feed.Items))
+		}
+	}
+}
 func TestParseContent(t *testing.T) {
 	tests := map[string]string{
 		"rss_2.0_content_encoded": "<p><a href=\"https://example.com/\">Example.com</a> is an example site.</p>",
@@ -23,6 +49,54 @@ func TestParseContent(t *testing.T) {
 
 		if feed.Items[0].Content != want {
 			t.Fatalf("%s: expected %s, got %s", test, want, feed.Items[0].Content)
+		}
+	}
+}
+
+func TestParseItemDateOK(t *testing.T) {
+	tests := map[string]string{
+		"rss_2.0":                 "2009-09-06 16:45:00 +0000 +0000",
+		"rss_2.0_content_encoded": "2009-09-06 16:45:00 +0000 +0000",
+		"rss_2.0_enclosure":       "2009-09-06 16:45:00 +0000 +0000",
+		"rss_2.0-1":               "2003-06-03 09:39:21 +0000 GMT",
+		"rss_2.0-1_enclosure":     "2016-05-14 18:39:34 +0300 +0300",
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if fmt.Sprintf("%s", feed.Items[0].Date) != want {
+			t.Fatalf("%s: expected %q, got %q", test, want, feed.Items[0].Date)
+		}
+	}
+}
+
+func TestParseItemDateFailure(t *testing.T) {
+	tests := map[string]string{
+		"rss_2.0": "0001-01-01 00:00:00 +0000 UTC",
+	}
+
+	for test, want := range tests {
+		data, err := ioutil.ReadFile("testdata/" + test)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", test, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", test, err)
+		}
+
+		if fmt.Sprintf("%s", feed.Items[1].Date) != want {
+			t.Fatalf("%s: expected %q, got %q", test, want, feed.Items[1].Date)
 		}
 	}
 }

--- a/rss_test.go
+++ b/rss_test.go
@@ -130,7 +130,7 @@ func TestItemGUIDs(t *testing.T) {
 		t.Fatalf("Failed fetching testdata 'rss_2.0': %v", err)
 	}
 
-	if len(feed1.Items) != 1 {
+	if len(feed1.Items) != 2 {
 		t.Errorf("Expected one item in feed 'rss_2.0', got %v", len(feed1.Items))
 	}
 

--- a/testdata/rss_2.0
+++ b/testdata/rss_2.0
@@ -17,5 +17,14 @@ description.</description>
   <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
  </item>
 
+ <item>
+  <title>Example entry with unparsable pubDate</title>
+  <description>Here is some text containing an interesting
+description.</description>
+  <link>http://www.wikipedia.org/</link>
+  <guid>1199152f-ea0e-4233-85d0-181002f424d7</guid>
+  <pubDate>This pubDate is not parsable.</pubDate>
+ </item>
+
 </channel>
 </rss>


### PR DESCRIPTION
Sadly, there are feeds out there that do not follow the standard. Often I encouter unparsable `date` or `pubDate` elements:

    "Wed May 10 2017 00:00:00 GMT+0000 (Coordinated Universal Time)"
    "Wed, 24 May 2017, 11:05"
    "31.05.2017"

I've decided to not accept such dates that do not follow the RFCs but to drop them.

This PR changes the behaviour and does not not stop parsing of such a feed. Instead the default value of `0001-01-01 00:00:00 +0000 UTC` is used.
