### PR TITLE
fix atom feeds with html/xml inside content

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -47,7 +47,7 @@ func parseAtom(data []byte) (*Feed, error) {
 		next := new(Item)
 		next.Title = item.Title
 		next.Summary = item.Summary
-		next.Content = item.Content
+		next.Content = item.Content.RAWContent
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err == nil {
@@ -98,6 +98,10 @@ func parseAtom(data []byte) (*Feed, error) {
 	return out, nil
 }
 
+type RAWContent struct {
+	RAWContent string `xml:",innerxml"`
+}
+
 type atomFeed struct {
 	XMLName     xml.Name   `xml:"feed"`
 	Title       string     `xml:"title"`
@@ -112,7 +116,7 @@ type atomItem struct {
 	XMLName   xml.Name   `xml:"entry"`
 	Title     string     `xml:"title"`
 	Summary   string     `xml:"summary"`
-	Content   string     `xml:"content"`
+	Content   RAWContent `xml:"content"`
 	Links     []atomLink `xml:"link"`
 	Date      string     `xml:"updated"`
 	DateValid bool

--- a/atom_test.go
+++ b/atom_test.go
@@ -34,6 +34,7 @@ func TestParseAtomContent(t *testing.T) {
 		"atom_1.0":           "Volltext des Weblog-Eintrags",
 		"atom_1.0_enclosure": "Volltext des Weblog-Eintrags",
 		"atom_1.0-1":         "",
+		"atom_1.0_html":      "<body>html</body>",
 	}
 
 	for test, want := range tests {

--- a/testdata/atom_1.0_html
+++ b/testdata/atom_1.0_html
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <author>
+    <name>Autor des Weblogs</name>
+  </author>
+  <title>Titel des Weblogs</title>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <updated>2003-12-14T10:20:09Z</updated>
+
+  <entry>
+    <title>Titel des Weblog-Eintrags</title>
+    <link href="http://example.org/2003/12/13/atom-beispiel"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary>Zusammenfassung des Weblog-Eintrags</summary>
+    <content><body>html</body></content>
+  </entry>
+</feed>


### PR DESCRIPTION
Hi there,

I have some html inside feed's `content`, making currently `Content` empty.

This patch fixes that. It may be required to do the same thing for RSS.