### PR TITLE
Time improvements

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -47,7 +47,7 @@ func parseAtom(data []byte) (*Feed, error) {
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err == nil {
-				item.DateValid = true
+				next.DateValid = true
 			}
 		}
 		next.ID = item.ID

--- a/atom_test.go
+++ b/atom_test.go
@@ -54,5 +54,9 @@ func TestParseAtomContent(t *testing.T) {
 		if feed.Items[0].Content != want {
 			t.Errorf("%s: got %q, want %q", name, feed.Items[0].Content, want)
 		}
+
+		if !feed.Items[0].DateValid {
+			t.Errorf("%s: Invalid date: %q", name, feed.Items[0].Date)
+		}
 	}
 }

--- a/rss_1.0.go
+++ b/rss_1.0.go
@@ -87,12 +87,12 @@ func parseRSS1(data []byte) (*Feed, error) {
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err == nil {
-				item.DateValid = true
+				next.DateValid = true
 			}
 		} else if item.PubDate != "" {
 			next.Date, err = parseTime(item.PubDate)
 			if err == nil {
-				item.DateValid = true
+				next.DateValid = true
 			}
 		}
 		next.ID = item.ID

--- a/rss_1.0_test.go
+++ b/rss_1.0_test.go
@@ -26,5 +26,15 @@ func TestParseRSS(t *testing.T) {
 		if feed.Title != want {
 			t.Errorf("%s: got %q, want %q", name, feed.Title, want)
 		}
+
+		if len(feed.Items) != 40 {
+			t.Errorf("%v: expected 40 items, got: %v", name, len(feed.Items))
+		} else {
+			for i, item := range feed.Items {
+				if !item.DateValid {
+					t.Errorf("%v Invalid date for item (#%v): %v", name, i, item.Title)
+				}
+			}
+		}
 	}
 }

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -93,12 +93,12 @@ func parseRSS2(data []byte) (*Feed, error) {
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err == nil {
-				item.DateValid = true
+				next.DateValid = true
 			}
 		} else if item.PubDate != "" {
 			next.Date, err = parseTime(item.PubDate)
 			if err == nil {
-				item.DateValid = true
+				next.DateValid = true
 			}
 		}
 		next.ID = item.ID

--- a/rss_2.0_test.go
+++ b/rss_2.0_test.go
@@ -77,7 +77,9 @@ func TestParseItemDateOK(t *testing.T) {
 			t.Fatalf("Parsing %s: %v", name, err)
 		}
 
-		if fmt.Sprintf("%s", feed.Items[0].Date) != want {
+		if !feed.Items[0].DateValid {
+			t.Errorf("%s: date %q invalid!", name, feed.Items[0].Date)
+		} else if fmt.Sprintf("%s", feed.Items[0].Date) != want {
 			t.Errorf("%s: got %q, want %q", name, feed.Items[0].Date, want)
 		}
 	}

--- a/time.go
+++ b/time.go
@@ -1,37 +1,69 @@
 package rss
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
+
+// TimeLayoutsLoadLocation are time layouts
+// which do not contain the location as a fixed
+// constant. Instead of -0700, they use MST.
+// Golang does not load the timezone by default,
+// which means parseTime calls
+// `time.LoadLocation(t.Location().String())`
+// and then applies the offset returned by
+// LoadLocation to the result.
+var TimeLayoutsLoadLocation = []string{
+	"Mon, 2 Jan 2006 15:04:05 MST",
+	"Mon, 2 Jan 06 15:04:05 MST",
+	"2 Jan 2006 15:04:05 MST",
+	"2 Jan 06 15:04:05 MST",
+	"Jan 2, 2006 15:04 PM MST",
+	"Jan 2, 06 15:04 PM MST",
+
+	time.RFC1123,
+	time.RFC850,
+	time.RFC822,
+}
 
 // TimeLayouts is contains a list of time.Parse() layouts that are used in
 // attempts to convert item.Date and item.PubDate string to time.Time values.
 // The layouts are attempted in ascending order until either time.Parse()
 // does not return an error or all layouts are attempted.
 var TimeLayouts = []string{
-	"Mon, _2 Jan 2006 15:04:05 Z",
-	"Mon, _2 Jan 2006 15:04:05 MST",
-	"Mon, _2 Jan 06 15:04:05 MST",
-	"Mon, _2 Jan 2006 15:04:05 -0700",
-	"Mon, _2 Jan 06 15:04:05 -0700",
-	"_2 Jan 2006 15:04:05 MST",
-	"_2 Jan 06 15:04:05 MST",
-	"_2 Jan 2006 15:04:05 -0700",
-	"_2 Jan 06 15:04:05 -0700",
+	"Mon, 2 Jan 2006 15:04:05 Z",
+	"Mon, 2 Jan 2006 15:04:05 -0700",
+	"Mon, 2 Jan 06 15:04:05 -0700",
+	"2 Jan 2006 15:04:05 -0700",
+	"2 Jan 06 15:04:05 -0700",
 	"2006-01-02 15:04:05",
-	"Jan _2, 2006 15:04 PM MST",
-	"Jan _2, 06 15:04 PM MST",
 	time.ANSIC,
 	time.UnixDate,
 	time.RubyDate,
-	time.RFC822,
 	time.RFC822Z,
-	time.RFC850,
-	time.RFC1123,
 	time.RFC1123Z,
 	time.RFC3339,
 	time.RFC3339Nano,
+
+	// Not some common time zones. While they are odd,
+	// they can occur but we should only check
+	// them last (to slightly improve runtime).
+	// We also always use the offset, because the
+	// texual representation can be ambiguous.
+	// For example, PST can have different rules
+	// in different locals:
+	// https://news.ycombinator.com/item?id=10199812
+	"2 Jan 2006 15:04:05 -0700 MST",
+	"2 Jan 2006 15:04:05 MST -0700",
+	"Mon, 2 Jan 2006 15:04:05 MST -0700",
+	"Mon, 2 Jan 2006 15:04:05 -0700 MST",
+	"2 Jan 06 15:04:05 -0700 MST",
+	"2 Jan 06 15:04:05 MST -0700",
+	"Jan 2, 2006 15:04 PM -0700 MST",
+	"Jan 2, 2006 15:04 PM MST -0700",
+	"Jan 2, 06 15:04 PM MST -0700",
+	"Jan 2, 06 15:04 PM -0700 MST",
 }
 
 func parseTime(s string) (time.Time, error) {
@@ -43,7 +75,33 @@ func parseTime(s string) (time.Time, error) {
 	for _, layout := range TimeLayouts {
 		t, e = time.Parse(layout, s)
 		if e == nil {
-			return t, e
+			return t, nil
+		}
+	}
+
+	for _, layout := range TimeLayoutsLoadLocation {
+		t, e = time.Parse(layout, s)
+		if e != nil {
+			continue
+		}
+
+		// In case LoadLocation returns an error
+		// we want to return the time and error
+		// as is. LoadLocation commonly returns an
+		// error if tzinfo is not installed.
+		// This often happens when running go applications
+		// inside an alpine docker container.
+		loc, err := time.LoadLocation(t.Location().String())
+		if err != nil {
+			if debug {
+				fmt.Printf("[w] could not load timezone: %q\n", e)
+			}
+			return t, err
+		}
+
+		t, e = time.ParseInLocation(layout, s, loc)
+		if e == nil {
+			return t, nil
 		}
 	}
 

--- a/time_test.go
+++ b/time_test.go
@@ -64,3 +64,46 @@ func TestParseWithTwoDigitYear(t *testing.T) {
 		t.Errorf("expected no err and year to be 2016, got err %v, and year %v", err, tv.Year())
 	}
 }
+
+// TestParseTime tests parseTime against some
+// common and some not so valid time formts.
+// Feel free to add more by adding another slice
+// to the tests
+func TestParseTime(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected time.Time
+	}{{
+		"Sun, 06 Sep 2009 16:20:00 +0000",
+		time.Date(2009, 9, 6, 16, 20, 0, 0, time.UTC),
+	}, {
+		"Sun, 06 Sep 2009 16:20:00 -0300",
+		time.Date(2009, 9, 6, 19, 20, 0, 0, time.UTC),
+	}, {
+		"06 Sep 2009 16:18:00 EST",
+		time.Date(2009, 9, 6, 21, 18, 0, 0, time.UTC),
+	}, {
+		"Sun, 06 Sep 2009 16:18:00 EST",
+		time.Date(2009, 9, 6, 21, 18, 0, 0, time.UTC),
+	}, {
+		"Sun, 06 Sep 2010 16:43:59 EST +0100", // ignore EST
+		time.Date(2010, 9, 6, 15, 43, 59, 0, time.UTC),
+	}, {
+		"Sun, 06 Sep 2009 16:18:00 +0200 EST", // ignore EST
+		time.Date(2009, 9, 6, 14, 18, 0, 0, time.UTC),
+	}, {
+		"Sun, 06 Sep 2009 16:18:00 +0200",
+		time.Date(2009, 9, 6, 14, 18, 0, 0, time.UTC),
+	}}
+
+	for _, c := range tests {
+		time, err := parseTime(c.in)
+		if err != nil {
+			t.Errorf("%q Date is not valid: %q.", c.in, err)
+		}
+
+		if d := time.UTC(); !d.Equal(c.expected) {
+			t.Errorf("%q: %q != %q.", c.in, c.expected, d)
+		}
+	}
+}


### PR DESCRIPTION
tl;dr:

 - all rss/atom parses did not set DateValid correctly at all. This has now been fixed (commit 1)
 - improved `parseTime` to better handle timezones (I hate them too... -- commit 2)
 - More tests!

commit bbde65d3b9d3e67c0dba33b68dca8096aa0bff2d
Author: Matteo Kloiber <info@matt3o12.de>
Date:   Tue May 8 14:57:09 2018 +0200

    parseTime: text timezones are now parsed correctly
    
    If a format contains the timezone as text,
    such as 'Jan 2, 2006 15:04 PM MST',
    golang does not automacitally load the timezone
    offset. This has to be done manually through
    LoadTimezone. The variable
    `TimeLayoutsLoadLocation` contains all parse
    formats with such a timezone. parseTime now
    loads the timezone (if possible) and returns
    the time in the correct timezone.
    
    Tests have also been added to test more time
    formats. TimeLayouts have also been added
    for date that contain both the texual timezone
    and offset (such as Mon Jan _2 15:04:05 MST
    -0200). In this case, parseTime always uses
    the offset, even if it conflicts with the
    known offset because it can be ambiguous:
    https://news.ycombinator.com/item?id=10199812

commit 7389b38786afa0d7e9e18df919117be88cefa614
Author: Matteo Kloiber <info@matt3o12.de>
Date:   Tue May 8 13:36:56 2018 +0200

    DateValid is now set correctly
    
    Due to a bug, DateValid was only set for the
    protocol specific item (rss_1_0, etc), not
    the returned item. This has now been fixed.
    The unit tests have been extended to ensure
    that for at least one item for each protocol.
