### PR TITLE
Times without timezones are now parsed as UTC

### DIFF
--- a/time.go
+++ b/time.go
@@ -33,10 +33,14 @@ var TimeLayoutsLoadLocation = []string{
 // does not return an error or all layouts are attempted.
 var TimeLayouts = []string{
 	"Mon, 2 Jan 2006 15:04:05 Z",
+	"Mon, 2 Jan 2006 15:04:05",
 	"Mon, 2 Jan 2006 15:04:05 -0700",
 	"Mon, 2 Jan 06 15:04:05 -0700",
+	"Mon, 2 Jan 06 15:04:05",
 	"2 Jan 2006 15:04:05 -0700",
+	"2 Jan 2006 15:04:05",
 	"2 Jan 06 15:04:05 -0700",
+	"2006-01-02 15:04:05 -0700",
 	"2006-01-02 15:04:05",
 	time.ANSIC,
 	time.UnixDate,

--- a/time_test.go
+++ b/time_test.go
@@ -77,11 +77,17 @@ func TestParseTime(t *testing.T) {
 		"Sun, 06 Sep 2009 16:20:00 +0000",
 		time.Date(2009, 9, 6, 16, 20, 0, 0, time.UTC),
 	}, {
+		"Sun, 06 Sep 2009 16:20:00",
+		time.Date(2009, 9, 6, 16, 20, 0, 0, time.UTC),
+	}, {
 		"Sun, 06 Sep 2009 16:20:00 -0300",
 		time.Date(2009, 9, 6, 19, 20, 0, 0, time.UTC),
 	}, {
 		"06 Sep 2009 16:18:00 EST",
 		time.Date(2009, 9, 6, 21, 18, 0, 0, time.UTC),
+	}, {
+		"06 Sep 2009 16:18:00",
+		time.Date(2009, 9, 6, 16, 18, 0, 0, time.UTC),
 	}, {
 		"Sun, 06 Sep 2009 16:18:00 EST",
 		time.Date(2009, 9, 6, 21, 18, 0, 0, time.UTC),


### PR DESCRIPTION
	Some RSS such as [1] do not provide a timezone.
	Those readers are now parsed as UTC time zones.

	1: https://www.discoverdev.io/




--- 

I might find another few edge cases where rss feeds provide weird or unusual time formats. I will add them if I find another one. I would appreciate if you would also tag this commit after you have merged it. Thank you for your awesome RSS parser ;)

