### PR TITLE
Allow multiple categories for RSS2.0

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -206,7 +206,7 @@ type Item struct {
 	Title      string    `json:"title"`
 	Summary    string    `json:"summary"`
 	Content    string    `json:"content"`
-	Category   string    `json:"category"`
+	Categories []string  `json:"category"`
 	Link       string    `json:"link"`
 	Date       time.Time `json:"date"`
 	DateValid  bool
@@ -229,7 +229,7 @@ func (i *Item) Format(indent int) string {
 		fmt.Fprintf(w, "\xff%s\xffItem {\n", single)
 		fmt.Fprintf(w, "\xff%s\xffTitle:\t%q\n", double, i.Title)
 		fmt.Fprintf(w, "\xff%s\xffSummary:\t%q\n", double, i.Summary)
-		fmt.Fprintf(w, "\xff%s\xffCategory:\t%q\n", double, i.Category)
+		fmt.Fprintf(w, "\xff%s\xffCategories:\t%q\n", double, i.Categories)
 		fmt.Fprintf(w, "\xff%s\xffLink:\t%s\n", double, i.Link)
 		fmt.Fprintf(w, "\xff%s\xffDate:\t%s\n", double, i.Date.Format(DATE))
 		fmt.Fprintf(w, "\xff%s\xffID:\t%s\n", double, i.ID)

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -88,7 +88,7 @@ func parseRSS2(data []byte) (*Feed, error) {
 		next.Title = item.Title
 		next.Summary = item.Description
 		next.Content = item.Content
-		next.Category = item.Category
+		next.Categories = item.Categories
 		next.Link = item.Link
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
@@ -146,12 +146,14 @@ type rss2_0Link struct {
 	Chardata string `xml:",chardata"`
 }
 
+type rss2_0Categories []string
+
 type rss2_0Item struct {
 	XMLName     xml.Name `xml:"item"`
 	Title       string   `xml:"title"`
 	Description string   `xml:"description"`
 	Content     string   `xml:"encoded"`
-	Category    string   `xml:"category"`
+	Categories  rss2_0Categories `xml:"category"`
 	Link        string   `xml:"link"`
 	PubDate     string   `xml:"pubDate"`
 	Date        string   `xml:"date"`

--- a/rss_2.0_test.go
+++ b/rss_2.0_test.go
@@ -33,6 +33,7 @@ func TestParseItemLen(t *testing.T) {
 		}
 	}
 }
+
 func TestParseContent(t *testing.T) {
 	tests := map[string]string{
 		"rss_2.0_content_encoded": "<p><a href=\"https://example.com/\">Example.com</a> is an example site.</p>",
@@ -108,6 +109,30 @@ func TestParseItemDateFailure(t *testing.T) {
 
 		if feed.Items[1].DateValid {
 			t.Errorf("%s: got unexpected valid date", name)
+		}
+	}
+}
+
+func TestParseCategories(t *testing.T) {
+	tests := map[string]int{
+		"rss_2.0-1_enclosure": 2,
+		"rss_2.0_enclosure":   0,
+	}
+
+	for test, want := range tests {
+		name := filepath.Join("testdata", test)
+		data, err := ioutil.ReadFile(name)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", name, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", name, err)
+		}
+
+		if len(feed.Items[0].Categories) != want {
+			t.Errorf("%s: got %q, want %q", name, feed.Items[0].Categories, want)
 		}
 	}
 }


### PR DESCRIPTION
According to https://validator.w3.org/feed/docs/rss2.html, there might be many categories in an entry:

```
category | Specify one or more categories that the channel belongs to. Follows the same rules as the <item>-level category element. More info.
```

This PR changes the type of the category to an array and allows multiple categories to be parsed. 