### PR TITLE
Fix the image compatible issue

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -209,6 +209,7 @@ type Item struct {
 	Categories []string  `json:"category"`
 	Link       string    `json:"link"`
 	Date       time.Time `json:"date"`
+	Image      *Image    `json:"image"`
 	DateValid  bool
 	ID         string       `json:"id"`
 	Enclosures []*Enclosure `json:"enclosures"`
@@ -273,6 +274,7 @@ func (e *Enclosure) Get() (io.ReadCloser, error) {
 // Image maps an image.
 type Image struct {
 	Title  string `json:"title"`
+	Href   string `json:"href"`
 	URL    string `json:"url"`
 	Height uint32 `json:"height"`
 	Width  uint32 `json:"width"`

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -90,6 +90,7 @@ func parseRSS2(data []byte) (*Feed, error) {
 		next.Content = item.Content
 		next.Categories = item.Categories
 		next.Link = item.Link
+		next.Image = item.Image.Image()
 		if item.Date != "" {
 			next.Date, err = parseTime(item.Date)
 			if err == nil {
@@ -149,14 +150,15 @@ type rss2_0Link struct {
 type rss2_0Categories []string
 
 type rss2_0Item struct {
-	XMLName     xml.Name `xml:"item"`
-	Title       string   `xml:"title"`
-	Description string   `xml:"description"`
-	Content     string   `xml:"encoded"`
+	XMLName     xml.Name         `xml:"item"`
+	Title       string           `xml:"title"`
+	Description string           `xml:"description"`
+	Content     string           `xml:"encoded"`
 	Categories  rss2_0Categories `xml:"category"`
-	Link        string   `xml:"link"`
-	PubDate     string   `xml:"pubDate"`
-	Date        string   `xml:"date"`
+	Link        string           `xml:"link"`
+	PubDate     string           `xml:"pubDate"`
+	Date        string           `xml:"date"`
+	Image       rss2_0Image      `xml:"image"`
 	DateValid   bool
 	ID          string            `xml:"guid"`
 	Enclosures  []rss2_0Enclosure `xml:"enclosure"`
@@ -179,6 +181,7 @@ func (r *rss2_0Enclosure) Enclosure() *Enclosure {
 
 type rss2_0Image struct {
 	XMLName xml.Name `xml:"image"`
+	Href    string   `xml:"href,attr"`
 	Title   string   `xml:"title"`
 	URL     string   `xml:"url"`
 	Height  int      `xml:"height"`
@@ -188,6 +191,7 @@ type rss2_0Image struct {
 func (i *rss2_0Image) Image() *Image {
 	out := new(Image)
 	out.Title = i.Title
+	out.Href = i.Href
 	out.URL = i.URL
 	out.Height = uint32(i.Height)
 	out.Width = uint32(i.Width)


### PR DESCRIPTION
I found a potential image issue of the RSS parsing process. See the details below:

```
An image to associate with your podcast. It must not be blocked to Googlebot. You can provide an image using any of the following tags:

<itunes:image>
<image>
  <link>...</link>
  <title>...</title>
  <url>...</url>
</image>
When using RSS <image> tags, you must include a nested <link> element that points to the podcast homepage, and a nested <title> tag that matches the <title> element in the homepage.

Example: <itunes:image href="https://google.com/google_podcast_cover_art.jpg"/>
```

## Reference
* https://support.google.com/podcast-publishers/answer/9889544?hl=en