### PR TITLE
Suport get the categories of a podcast channel

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -92,6 +92,7 @@ type Feed struct {
 	Link        string              `json:"link"`      // Link to the creator's website.
 	UpdateURL   string              `json:"updateurl"` // URL of the feed itself.
 	Image       *Image              `json:"image"`     // Feed icon.
+	Categories  []string            `json:"categories"`
 	Items       []*Item             `json:"items"`
 	ItemMap     map[string]struct{} `json:"itemmap"` // Used in checking whether an item has been seen before.
 	Refresh     time.Time           `json:"refresh"` // Earliest time this feed should next be checked.

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -27,6 +27,7 @@ func parseRSS2(data []byte) (*Feed, error) {
 	out := new(Feed)
 	out.Title = channel.Title
 	out.Description = channel.Description
+	out.Categories = channel.Categories.toArray()
 	for _, link := range channel.Link {
 		if link.Rel == "" && link.Type == "" && link.Href == "" && link.Chardata != "" {
 			out.Link = link.Chardata
@@ -128,16 +129,36 @@ type rss2_0Feed struct {
 	Channel *rss2_0Channel `xml:"channel"`
 }
 
+type rss2_0Category struct {
+	XMLName xml.Name `xml:"category"`
+	Name    string   `xml:"text,attr"`
+}
+
+type rss2_0CategorySlice []rss2_0Category
+
+func (r rss2_0CategorySlice) toArray() (result []string) {
+	count := len(r)
+	if count == 0 || r == nil {
+		return
+	}
+	result = make([]string, count)
+	for i, _ := range r {
+		result[i] = r[i].Name
+	}
+	return
+}
+
 type rss2_0Channel struct {
-	XMLName     xml.Name     `xml:"channel"`
-	Title       string       `xml:"title"`
-	Description string       `xml:"description"`
-	Link        []rss2_0Link `xml:"link"`
-	Image       rss2_0Image  `xml:"image"`
-	Items       []rss2_0Item `xml:"item"`
-	MinsToLive  int          `xml:"ttl"`
-	SkipHours   []int        `xml:"skipHours>hour"`
-	SkipDays    []string     `xml:"skipDays>day"`
+	XMLName     xml.Name            `xml:"channel"`
+	Title       string              `xml:"title"`
+	Description string              `xml:"description"`
+	Link        []rss2_0Link        `xml:"link"`
+	Image       rss2_0Image         `xml:"image"`
+	Categories  rss2_0CategorySlice `xml:"category"`
+	Items       []rss2_0Item        `xml:"item"`
+	MinsToLive  int                 `xml:"ttl"`
+	SkipHours   []int               `xml:"skipHours>hour"`
+	SkipDays    []string            `xml:"skipDays>day"`
 }
 
 type rss2_0Link struct {

--- a/rss_2.0_test.go
+++ b/rss_2.0_test.go
@@ -136,3 +136,27 @@ func TestParseCategories(t *testing.T) {
 		}
 	}
 }
+
+func TestParseChannelCategories(t *testing.T) {
+	tests := map[string]int{
+		"rss_2.0-1_enclosure": 2,
+		"rss_2.0_enclosure":   1,
+	}
+
+	for test, want := range tests {
+		name := filepath.Join("testdata", test)
+		data, err := ioutil.ReadFile(name)
+		if err != nil {
+			t.Fatalf("Reading %s: %v", name, err)
+		}
+
+		feed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parsing %s: %v", name, err)
+		}
+
+		if len(feed.Categories) != want {
+			t.Errorf("%s: got %q, want %q", name, feed.Items[0].Categories, want)
+		}
+	}
+}

--- a/testdata/rss_2.0-1_enclosure
+++ b/testdata/rss_2.0-1_enclosure
@@ -14,7 +14,9 @@
         <copyright>2012 - VOA</copyright>   
         <ttl>60</ttl>        
         <lastBuildDate>Sun, 15 May 2016 13:53:13 +0300</lastBuildDate> 
-        <generator>Pangea CMS – VOA</generator>        
+        <generator>Pangea CMS – VOA</generator>
+        <category text="Technology"></category>
+        <category text="Society \u0026 Culture"></category>
         <atom:link href="http://amharic.voanews.com/api/zt$gteitjt" rel="self" type="application/rss+xml" />
     		<item>
             <title>አሜሪካ ለኢትዮጵያ ተጨማሪ እርዳታ ሰጠች</title>

--- a/testdata/rss_2.0_enclosure
+++ b/testdata/rss_2.0_enclosure
@@ -7,6 +7,7 @@
  <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000</lastBuildDate>
  <pubDate>Mon, 06 Sep 2009 16:45:00 +0000</pubDate>
  <ttl>1800</ttl>
+ <category text="Technology"></category>
 
  <item>
   <title>Example entry</title>


### PR DESCRIPTION
Normally, all the episodes of a channel belong to some specific categories.

See the reference: https://support.google.com/podcast-publishers/answer/9889544?hl=en#zippy=%2Crecommended-categories